### PR TITLE
feat(screenshare): add session persistence via portal restore tokens

### DIFF
--- a/cosmic-connect-daemon/src/config.rs
+++ b/cosmic-connect-daemon/src/config.rs
@@ -284,6 +284,13 @@ pub struct PluginConfig {
     #[serde(default = "default_true")]
     pub enable_screenshare: bool,
 
+    /// Remember screenshare source selection between sessions
+    ///
+    /// When enabled, the portal restore token is saved so the user doesn't
+    /// need to re-select their capture source on every screenshare start.
+    #[serde(default = "default_true")]
+    pub screenshare_restore_session: bool,
+
     /// Enable MouseKeyboardShare plugin (Synergy-like input sharing)
     #[serde(default = "default_true")]
     pub enable_mousekeyboardshare: bool,
@@ -449,6 +456,7 @@ impl Default for PluginConfig {
             enable_audiostream: true,
             enable_filesync: true,
             enable_screenshare: true,
+            screenshare_restore_session: true,
             enable_mousekeyboardshare: true,
             enable_networkshare: true,
             enable_camera: true,

--- a/cosmic-connect-daemon/src/main.rs
+++ b/cosmic-connect-daemon/src/main.rs
@@ -531,7 +531,9 @@ impl Daemon {
         if config.plugins.enable_screenshare {
             info!("Registering ScreenShare plugin factory");
             manager
-                .register_factory(Arc::new(ScreenSharePluginFactory))
+                .register_factory(Arc::new(ScreenSharePluginFactory::with_restore_session(
+                    config.plugins.screenshare_restore_session,
+                )))
                 .context("Failed to register ScreenShare plugin factory")?;
         }
 


### PR DESCRIPTION
## Summary

Closes #189

Remember the previously selected capture source so users don't need to re-select their monitor/window on every screenshare start. The XDG Desktop Portal supports `RestoreData` that persists source selections via a `restore_token` + `PersistMode` — this PR wires that up.

- Pass restore token to `select_sources()` with `PersistMode::ExplicitlyRevoked`
- Save token to `~/.local/share/cosmic/cosmic-connect/screenshare_session.json` after each session
- Load and reuse token on next screenshare start (portal auto-selects same source)
- Fall back to the selection dialog when the previous source is unavailable
- Add `screenshare_restore_session` config option in `daemon.toml` (default: `true`)
- Thread config into `ScreenSharePluginFactory::with_restore_session()`

## Test plan

- [x] `cargo check --workspace` — 0 warnings, 0 errors
- [x] `cargo test -p cosmic-connect-protocol --lib` — 621 passed (14 screenshare, 6 new)
- [x] `cargo test -p cosmic-connect-daemon` — 28 passed
- [x] `cargo test --doc -p cosmic-connect-protocol` — 165 passed
- [ ] Manual: start screenshare → select monitor → stop → start again → should auto-select same monitor
- [ ] Manual: check `~/.local/share/cosmic/cosmic-connect/screenshare_session.json` exists after first session
- [ ] Manual: set `screenshare_restore_session = false` in config → verify dialog always shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)