### PR TITLE
feat(display-stream): handle display transforms in capture pipeline

### DIFF
--- a/cosmic-display-stream/src/lib.rs
+++ b/cosmic-display-stream/src/lib.rs
@@ -98,7 +98,9 @@ pub mod output;
 pub mod pipewire;
 pub mod streaming;
 
-pub use capture::{BufferType, DamageRect, FrameStream, ScreenCapture, SessionState, VideoFrame};
+pub use capture::{
+    BufferType, DamageRect, FrameStream, ScreenCapture, SessionState, VideoFrame, VideoTransform,
+};
 pub use encoder::{EncodedFrame, EncoderConfig, EncoderType, VideoEncoder};
 pub use error::{DisplayStreamError, Result};
 pub use gbm_devices::{


### PR DESCRIPTION
## Summary

- Extract `SPA_META_VideoTransform` from PipeWire buffer metadata per-frame, following the existing `SPA_META_VideoDamage` extraction pattern
- Insert GStreamer `videoflip` element in encoder pipeline (`appsrc → videoflip → videoconvert → encoder → h264parse → appsink`) to correct frame orientation for rotated/flipped displays
- Add `VideoTransform` enum with 8 variants mapping SPA constants to `GstVideoOrientationMethod` values, including `needs_dimension_swap()` for 90°/270° rotations

## Details

Rotated displays (vertical monitors, flipped orientations) produce incorrectly oriented output in the capture pipeline. PipeWire provides `SPA_META_VideoTransform` metadata per-frame, but our code previously ignored it.

The `videoflip` element with `method=0` (identity) is a passthrough — zero overhead for normal displays. For 90°/270° rotations, GStreamer handles dimension swapping automatically during cap negotiation.

**Deferred:** RawFrame changes in `cosmic-connect-protocol` (Task 4 from plan) — the VNC encoder doesn't use transform metadata yet.

## Test plan

- [x] `cargo check -p cosmic-display-stream` — clean
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p cosmic-display-stream` — 70 unit + 8 doc-tests pass
- [x] `cargo test --workspace` — 1,118 passed, 0 failed
- [ ] Manual: `wlr-randr --output <name> --transform 90` then capture → verify frame is correctly oriented

🤖 Generated with [Claude Code](https://claude.com/claude-code)